### PR TITLE
Loading config file modification

### DIFF
--- a/src/main/java/org/powertac/factoredcustomer/FactoredCustomerService.java
+++ b/src/main/java/org/powertac/factoredcustomer/FactoredCustomerService.java
@@ -118,7 +118,7 @@ implements InitializationService, NewTariffListener
   {
     log.info("Attempting to load factored customer profiles from config resource: " + configResource);
     try {
-      InputStream configStream = ClassLoader.getSystemClassLoader().getResourceAsStream(configResource);
+      InputStream configStream = Thread.currentThread().getContextClassLoader().getResourceAsStream(configResource);
 
       DocumentBuilderFactory docBuilderFactory = DocumentBuilderFactory.newInstance();
       DocumentBuilder docBuilder = docBuilderFactory.newDocumentBuilder();

--- a/src/main/java/org/powertac/factoredcustomer/TimeseriesGenerator.java
+++ b/src/main/java/org/powertac/factoredcustomer/TimeseriesGenerator.java
@@ -84,7 +84,7 @@ final class TimeseriesGenerator
             throw new Error("Unknown builtin model parameters with name: " + paramsName);
             // break;
         case CLASSPATH:
-            paramsStream = ClassLoader.getSystemClassLoader().getResourceAsStream(paramsName);
+            paramsStream = Thread.currentThread().getContextClassLoader().getResourceAsStream(paramsName);
             break;
         case FILEPATH:
             try {
@@ -124,7 +124,7 @@ final class TimeseriesGenerator
             throw new Error("Unknown builtin series name: " + seriesName);
             // break;
         case CLASSPATH:
-            refStream = ClassLoader.getSystemClassLoader().getResourceAsStream(seriesName);
+            refStream = Thread.currentThread().getContextClassLoader().getResourceAsStream(seriesName);
             break;
         case FILEPATH:
             try {


### PR DESCRIPTION
It appears that system class loader in Tomcat/Jetty is not working the way it works in desktop enviroment. 

Tomcat in its classpath have only two files, none of them are config files for powertac plugins: bootstrap.jar and tools.jar.

Forcing tomcat/jetty to put config files into system class loader is not an easy task and probably not the best idea.

Proposed solution is to switch from retrieving config files using system class loader to using thread context class loader, as you can see in the source code modification.

I have sucessfully tested this solution with an Eclipse integrated version of Tomcat, a maven deployment of Jetty server, and standard competition run using maven call from bash (server-distribution). 

Thanks,
Jurica
