### PR TITLE
Fixed allocation logic for small multicontracting populations.

### DIFF
--- a/src/main/java/org/powertac/factoredcustomer/DefaultUtilityOptimizer.java
+++ b/src/main/java/org/powertac/factoredcustomer/DefaultUtilityOptimizer.java
@@ -447,7 +447,11 @@ class DefaultUtilityOptimizer implements UtilityOptimizer
                 int allocation;
                 if (i < (numTariffs - 1)) {
                     allocation = (int) Math.round(population * probabilities.get(i));
+                    if ((sumAllocations + allocation) > population) {
+                        allocation = population - sumAllocations;
+                    }
                     sumAllocations += allocation;
+                    if (sumAllocations == population) break;
                 } else {
                     allocation = population - sumAllocations;
                 }

--- a/src/main/resources/FactoredCustomers.xml
+++ b/src/main/resources/FactoredCustomers.xml
@@ -1,4 +1,4 @@
-<customers logAllocationDetails="TRUE" logCapacityDetails="TRUE" logUsageCharges="TRUE">
+<customers>
 
     <customer name="BrooksideHomes" count="1" creatorKey="" entityType="RESIDENTIAL">
         <capacityBundle id="" population="30000" powerType="CONSUMPTION" multiContracting="true" canNegotiate="false">


### PR DESCRIPTION
We were over-allocating the population when we have small populations and were faced with some number of identical tariffs.  This later caused us to try to unsubscribe that fictional population on a non-existent subscription which caused an NPE. 
