### PR TITLE
Fix bug introduced in yesterday's commit for allocation logic.

### DIFF
--- a/src/main/java/org/powertac/factoredcustomer/DefaultUtilityOptimizer.java
+++ b/src/main/java/org/powertac/factoredcustomer/DefaultUtilityOptimizer.java
@@ -445,13 +445,14 @@ class DefaultUtilityOptimizer implements UtilityOptimizer
             int sumAllocations = 0;
             for (int i=0; i < numTariffs; ++i) {
                 int allocation;
-                if (i < (numTariffs - 1)) {
+                if (sumAllocations == population) {
+                    allocation = 0;
+                } else if (i < (numTariffs - 1)) {
                     allocation = (int) Math.round(population * probabilities.get(i));
                     if ((sumAllocations + allocation) > population) {
                         allocation = population - sumAllocations;
                     }
                     sumAllocations += allocation;
-                    if (sumAllocations == population) break;
                 } else {
                     allocation = population - sumAllocations;
                 }


### PR DESCRIPTION
I was terminating the allocation loop early which resulted in an allocations array of insufficient length in some situations.
